### PR TITLE
Enable the "disabled" mode for symfony/phpunit-bridge

### DIFF
--- a/src/Codeception/Subscriber/ErrorHandler.php
+++ b/src/Codeception/Subscriber/ErrorHandler.php
@@ -103,7 +103,7 @@ class ErrorHandler implements EventSubscriberInterface
 
     private function registerDeprecationErrorHandler()
     {
-        if (class_exists('\Symfony\Bridge\PhpUnit\DeprecationErrorHandler')) {
+        if (class_exists('\Symfony\Bridge\PhpUnit\DeprecationErrorHandler') && 'disabled' !== getenv('SYMFONY_DEPRECATIONS_HELPER')) {
             // DeprecationErrorHandler only will be installed if array('PHPUnit_Util_ErrorHandler', 'handleError')
             // is installed or no other error handlers are installed.
             // So we will remove Symfony\Component\Debug\ErrorHandler if it's installed.


### PR DESCRIPTION
Deal with disabled mode for symfony/phpunit-bridge in the same way that symfony/phpunit-bridge bootstrap does as seen in https://github.com/symfony/symfony/commit/1b216477eec2dca22847460473f29144cdb02843#diff-81bfee6017752d99d3119f4ddb1a09edR27